### PR TITLE
Vector database support w/ Pinecone

### DIFF
--- a/_bootstrap/index.php
+++ b/_bootstrap/index.php
@@ -194,6 +194,8 @@ foreach ($objectContainers as $oC) {
     $manager->createObjectContainer($oC);
 }
 
+$manager->addField(\modmore\AIKit\Model\Message::class, 'is_vector_augmented', ['after' => 'tool_call_id']);
+
 $modx->getCacheManager()->refresh();
 
 $exTools = [

--- a/_bootstrap/index.php
+++ b/_bootstrap/index.php
@@ -108,6 +108,15 @@ if ($plugin) {
     ) {
         echo "Error creating modPluginEvent for AIKit Plugin.\n";
     }
+    if (
+        !createObject('modPluginEvent', array(
+            'pluginid' => $plugin->get('id'),
+            'event' => 'OnDocFormSave',
+            'priority' => 0,
+        ), array('pluginid', 'event'), false)
+    ) {
+        echo "Error creating modPluginEvent for AIKit Plugin.\n";
+    }
 }
 
 if (

--- a/_build/data/transport.settings.php
+++ b/_build/data/transport.settings.php
@@ -1,5 +1,7 @@
 <?php
 
+use modmore\AIKit\LLM\Vectors\Pinecone;
+
 $settingSource = [
     'model' => [
         'area' => 'configuration',
@@ -31,6 +33,23 @@ PROMPT,
     'openai_endpoint' => [
         'area' => 'openai',
         'value' => 'https://api.openai.com/v1/',
+    ],
+
+    'vector_database' => [
+        'area' => 'model',
+        'value' => Pinecone::class,
+    ],
+    'pinecone_endpoint' => [
+        'area' => 'pinecone',
+        'value' => '',
+    ],
+    'pinecone_api_key' => [
+        'area' => 'pinecone',
+        'value' => '',
+    ],
+    'pinecone_content_index' => [
+        'area' => 'pinecone',
+        'value' => '',
     ],
 ];
 

--- a/_build/elements/plugins/aikit.plugin.php
+++ b/_build/elements/plugins/aikit.plugin.php
@@ -3,6 +3,8 @@
  * @var \MODX\Revolution\modX $modx
  */
 
+use modmore\AIKit\LLM\Model;
+
 switch ($modx->event->name) {
     case 'OnManagerPageBeforeRender':
         $assetsUrl = $modx->getOption('aikit.assets_url', null, $modx->getOption('assets_url') . 'components/aikit/');
@@ -31,6 +33,34 @@ switch ($modx->event->name) {
 
 </script>
 HTML);
+        break;
+
+    case 'OnDocFormSave':
+        /**
+         * @var \MODX\Revolution\modX $modx
+         * @var \MODX\Revolution\modResource $resource
+         */
+        $model = new Model($modx);
+        if ($db = $model->getVectorDatabase()) {
+            $content = '';
+            $metadata = [];
+
+            // @todo support arbitrary fields/tvs as desirable
+            $fields = ['content', 'introtext', 'pagetitle'];
+
+            foreach ($fields as $field) {
+                $v = $resource->get($field);
+                $v = strip_tags($v);
+                $content .= $v . "\n";
+                $metadata[$field] = $v;
+            }
+
+            $content = strip_tags($content);
+            $db->index($resource->get('id'), $content, $metadata);
+
+            break;
+        }
+
         break;
 }
 

--- a/aikit.mysql.schema.xml
+++ b/aikit.mysql.schema.xml
@@ -36,6 +36,7 @@
         <field key="conversation" dbtype="int" precision="10" phptype="int" null="false" default="0" attributes="unsigned" />
         <field key="llm_id" dbtype="varchar" precision="190" phptype="string" null="false" default="" />
         <field key="tool_call_id" dbtype="varchar" precision="190" phptype="string" null="false" default="" />
+        <field key="is_vector_augmented" dbtype="tinyint" precision="1" phptype="boolean" null="false" default="0" />
 
         <field key="user_role" dbtype="varchar" precision="190" phptype="string" null="false" default="system" />
         <field key="user" dbtype="int" precision="10" phptype="int" null="false" default="0" attributes="unsigned" />

--- a/assets/components/aikit/mgr/aikit.js
+++ b/assets/components/aikit/mgr/aikit.js
@@ -371,6 +371,15 @@ class MessageRenderer {
                 </div>
             `;
         } else if (user_role === 'assistant') {
+            if (content.length > 0) {
+                content = md.render(content);
+
+                messageEl.innerHTML += `
+                    <div class="assistant-message">
+                        ${content}
+                    </div>
+                `;
+            }
             if (Object.values(msg.tool_calls).length > 0) {
                 const toolCallsContent = msg.tool_calls.map((toolCall, index) => {
                     const args = toolCall.function.arguments;
@@ -406,15 +415,6 @@ class MessageRenderer {
                     }
                 });
             }
-            else {
-                content = md.render(content);
-
-                messageEl.innerHTML = `
-                    <div class="assistant-message">
-                        ${content}
-                    </div>
-                `;
-            }
         } else if (user_role === 'tool') {
             let toolCallEl = this.messageContainer.querySelector('#tool-' + msg.tool_call_id);
             if (toolCallEl) {
@@ -434,7 +434,6 @@ class MessageRenderer {
                 </div>
             `;
         }
-
 
         return messageEl;
     }

--- a/core/components/aikit/src/API/Conversation/AwaitAPI.php
+++ b/core/components/aikit/src/API/Conversation/AwaitAPI.php
@@ -51,7 +51,6 @@ class AwaitAPI implements ApiInterface
             ]);
 
             if ($messageCount > 0) {
-                // @todo add missing user_username value
                 $messages = $this->modx->getCollection(Message::class, [
                     'conversation' => $conversationId,
                     'id:>' => $lastMessage,

--- a/core/components/aikit/src/LLM/Model.php
+++ b/core/components/aikit/src/LLM/Model.php
@@ -4,6 +4,7 @@ namespace modmore\AIKit\LLM;
 
 use modmore\AIKit\LLM\Models\OpenAI;
 use modmore\AIKit\LLM\Tools\ToolInterface;
+use modmore\AIKit\LLM\Vectors\VectorDatabaseInterface;
 use modmore\AIKit\Model\Conversation;
 use modmore\AIKit\Model\Message;
 use modmore\AIKit\Model\Tool;
@@ -104,5 +105,18 @@ class Model
                 $this->modx->log(modX::LOG_LEVEL_ERROR, 'Failed to load tool ' . $tool->get('id') . ': ' . $e->getMessage() . ' / ' . $e->getTraceAsString());
             }
         }
+    }
+
+    public function getVectorDatabase(): ?VectorDatabaseInterface
+    {
+        try {
+            $class = $this->modx->getOption('aikit.vector_database', null, '', true);
+            if (!empty($class) && is_subclass_of($class, VectorDatabaseInterface::class, true)) {
+                return new $class($this->modx);
+            }
+        } catch (\Throwable $e) {
+            $this->modx->log(modX::LOG_LEVEL_ERROR, 'Failed to load vector database: ' . $e->getMessage() . ' / ' . $e->getTraceAsString());
+        }
+        return null;
     }
 }

--- a/core/components/aikit/src/LLM/Vectors/Pinecone.php
+++ b/core/components/aikit/src/LLM/Vectors/Pinecone.php
@@ -1,0 +1,120 @@
+<?php
+
+namespace modmore\AIKit\LLM\Vectors;
+
+use GuzzleHttp\Client;
+use GuzzleHttp\Exception\GuzzleException;
+use GuzzleHttp\Exception\RequestException;
+use MODX\Revolution\modX;
+
+class Pinecone implements VectorDatabaseInterface
+{
+    private array $config;
+    private ?Client $client = null;
+    private string $contentIndex;
+    private modX $modx;
+
+    public function __construct(modX $modx, array $config = [])
+    {
+        $this->modx = $modx;
+        $this->config = $config;
+        $this->client = new Client([
+            'base_uri' => $config['endpoint'] ?? $this->modx->getOption('aikit.pinecone_endpoint'),
+            'headers' => [
+                'Api-Key' => $config['api_key'] ?? $this->modx->getOption('aikit.pinecone_api_key'),
+                'Content-Type' => 'application/json',
+                'X-Pinecone-API-Version' => '2025-01',
+            ],
+        ]);
+        $this->contentIndex = (string)$modx->getOption('aikit.pinecone_content_index');
+    }
+
+    public function index($id, string $content, array $metadata = []): bool
+    {
+        $data = [
+            'id' => 'resource_' . $id,
+            'text' => $content,
+            'resource_id' => $id,
+        ] + $metadata;
+
+        try {
+            $response = $this->client->post("/records/namespaces/{$this->contentIndex}/upsert", [
+                'json' => $data
+            ]);
+
+            if ($response->getStatusCode() !== 200) {
+                $this->modx->log(modX::LOG_LEVEL_ERROR, 'Pinecone non-200 response: ' . $response->getBody()->getContents());
+                return false;
+            }
+
+            return true;
+        } catch (RequestException $e) {
+            $this->modx->log(modX::LOG_LEVEL_ERROR, 'Pinecone exception: ' . $e->getResponse()->getBody()->getContents());
+            return false;
+        }
+    }
+
+    public function upsert(array $vectors, array $metadata = []): bool
+    {
+        try {
+            $response = $this->client?->post("databases/{$this->contentIndex}/vectors/upsert", [
+                'json' => [
+                    'vectors' => array_map(function ($vector, $key) use ($metadata) {
+                        return [
+                            'id' => (string)$key,
+                            'values' => $vector,
+                            'metadata' => $metadata[$key] ?? [],
+                        ];
+                    }, $vectors, array_keys($vectors)),
+                ],
+            ]);
+
+            return $response?->getStatusCode() === 200;
+        } catch (GuzzleException $e) {
+            return false;
+        }
+    }
+
+    public function delete(array $ids): bool
+    {
+        try {
+            $response = $this->client?->post("databases/{$this->contentIndex}/vectors/delete", [
+                'json' => [
+                    'ids' => $ids,
+                ],
+            ]);
+
+            return $response?->getStatusCode() === 200;
+        } catch (GuzzleException $e) {
+            return false;
+        }
+    }
+
+    public function query(array $vector, int $topK = 10, array $filters = []): array
+    {
+        try {
+            $response = $this->client?->post("databases/{$this->contentIndex}/query", [
+                'json' => [
+                    'vector' => $vector,
+                    'topK' => $topK,
+                    'filter' => $filters,
+                ],
+            ]);
+            if ($response?->getStatusCode() === 200) {
+                return json_decode($response->getBody()->getContents(), true);
+            }
+        } catch (GuzzleException $e) {
+        }
+
+        return [];
+    }
+
+    public function augmentChatCompletion(string $query, array $options = []): array
+    {
+        // Implementation depends on the embedding model being used
+        return [
+            'context' => [],
+            'augmented_prompt' => $query,
+        ];
+    }
+}

--- a/core/components/aikit/src/LLM/Vectors/VectorDatabaseInterface.php
+++ b/core/components/aikit/src/LLM/Vectors/VectorDatabaseInterface.php
@@ -8,15 +8,15 @@ interface VectorDatabaseInterface
 {
     public function __construct(modX $modx, array $config = []);
 
-    public function index($id, string $content, array $metadata = []): bool;
-
     /**
-     * Upsert vectors into the database
-     * @param array $vectors Array of vectors to insert/update
-     * @param array $metadata Optional metadata for the vectors
-     * @return bool Success status
+     * Insert/update (upsert) the data. Not yet vectorised, so may need additional logic for that.
+     *
+     * @param $id
+     * @param string $content
+     * @param array $metadata
+     * @return bool
      */
-    public function upsert(array $vectors, array $metadata = []): bool;
+    public function index($id, string $content, array $metadata = []): bool;
 
     /**
      * Delete vectors from the database
@@ -26,19 +26,10 @@ interface VectorDatabaseInterface
     public function delete(array $ids): bool;
 
     /**
-     * Query vectors by similarity
-     * @param array $vector Query vector
-     * @param int $topK Number of results to return
-     * @param array $filters Optional metadata filters
-     * @return array Query results
-     */
-    public function query(array $vector, int $topK = 10, array $filters = []): array;
-
-    /**
      * Augment chat completion with relevant context from vector search
      * @param string $query User query or message
      * @param array $options Additional options for RAG
      * @return array Context and augmented prompt
      */
-    public function augmentChatCompletion(string $query, array $options = []): string;
+    public function query(string $query, array $options = []): string;
 }

--- a/core/components/aikit/src/LLM/Vectors/VectorDatabaseInterface.php
+++ b/core/components/aikit/src/LLM/Vectors/VectorDatabaseInterface.php
@@ -40,5 +40,5 @@ interface VectorDatabaseInterface
      * @param array $options Additional options for RAG
      * @return array Context and augmented prompt
      */
-    public function augmentChatCompletion(string $query, array $options = []): array;
+    public function augmentChatCompletion(string $query, array $options = []): string;
 }

--- a/core/components/aikit/src/LLM/Vectors/VectorDatabaseInterface.php
+++ b/core/components/aikit/src/LLM/Vectors/VectorDatabaseInterface.php
@@ -1,0 +1,44 @@
+<?php
+
+namespace modmore\AIKit\LLM\Vectors;
+
+use MODX\Revolution\modX;
+
+interface VectorDatabaseInterface
+{
+    public function __construct(modX $modx, array $config = []);
+
+    public function index($id, string $content, array $metadata = []): bool;
+
+    /**
+     * Upsert vectors into the database
+     * @param array $vectors Array of vectors to insert/update
+     * @param array $metadata Optional metadata for the vectors
+     * @return bool Success status
+     */
+    public function upsert(array $vectors, array $metadata = []): bool;
+
+    /**
+     * Delete vectors from the database
+     * @param array $ids Vector IDs to delete
+     * @return bool Success status
+     */
+    public function delete(array $ids): bool;
+
+    /**
+     * Query vectors by similarity
+     * @param array $vector Query vector
+     * @param int $topK Number of results to return
+     * @param array $filters Optional metadata filters
+     * @return array Query results
+     */
+    public function query(array $vector, int $topK = 10, array $filters = []): array;
+
+    /**
+     * Augment chat completion with relevant context from vector search
+     * @param string $query User query or message
+     * @param array $options Additional options for RAG
+     * @return array Context and augmented prompt
+     */
+    public function augmentChatCompletion(string $query, array $options = []): array;
+}

--- a/core/components/aikit/src/Model/mysql/Message.php
+++ b/core/components/aikit/src/Model/mysql/Message.php
@@ -23,6 +23,7 @@ class Message extends \modmore\AIKit\Model\Message
             'conversation' => 0,
             'llm_id' => '',
             'tool_call_id' => '',
+            'is_vector_augmented' => 0,
             'user_role' => 'system',
             'user' => 0,
             'content' => '',
@@ -58,6 +59,14 @@ class Message extends \modmore\AIKit\Model\Message
                 'phptype' => 'string',
                 'null' => false,
                 'default' => '',
+            ),
+            'is_vector_augmented' => 
+            array (
+                'dbtype' => 'tinyint',
+                'precision' => '1',
+                'phptype' => 'boolean',
+                'null' => false,
+                'default' => 0,
             ),
             'user_role' => 
             array (


### PR DESCRIPTION
Create an index in Pinecone. Make sure it has a vectorisation model. 

Add your API Key and host to the aikit settings and make sure aikit.vector_database is set to `modmore\AIKit\LLM\Vectors\Pinecone`

Saving a resource will index its content in Pinecone.

Prompting the assistant will automatically check the prompt against Pinecone to see if there are any relevant resources. The relevant resource content is then included in the prompt automatically to give the assistant actual knowledge. 